### PR TITLE
Oven fix mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
   <title>Turkey Cooking Simulator</title>
   <style type="text/css">
   #demoCanvas{ touch-action: auto; }
+  body {overscroll-behavior-y: contain;}
 </style>
 </head>
   <body bgcolor="#250c00">
-
     <center>
     <div class="canvasContainer">
       <canvas id="demoCanvas" width="800" height="600" style="border:1px solid #000000"></canvas>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <head>
   <title>Turkey Cooking Simulator</title>
   <style type="text/css">
+  #demoCanvas{ touch-action: auto; }
 </style>
 </head>
   <body bgcolor="#250c00">
@@ -12,7 +13,7 @@
     </div>
   </center>
   </body>
-  <script src="//code.createjs.com/createjs-2013.09.25.min.js"></script>
+  <script src="//code.createjs.com/1.0.0/createjs.min.js"></script> 
   <script src="js/model.js"></script>
   <script src="js/soundmanager.js"></script>
   <script src="js/stories.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -328,6 +328,7 @@ function GameState(){
 	}
 }
 
+
 function GameUI( canvasElem, gameState ){
 	var that = this;
 
@@ -337,6 +338,7 @@ function GameUI( canvasElem, gameState ){
 
 	this.stage = new createjs.Stage( canvasElem );
 	this.stage.enableMouseOver(25);
+	createjs.Touch.enable(this.stage,true,false);
 
 	this.activeScreenName = "EndingScreen";
 	this.activeScreenObj = {};
@@ -391,7 +393,7 @@ function GameUI( canvasElem, gameState ){
 			that.stage.removeChild(items[index]);
 		}
 	});
-
+		
 	return {
 		draw : function(){
 			if( gameState.screenState == SCREEN_OUT ){
@@ -416,6 +418,7 @@ function GameUI( canvasElem, gameState ){
 			that.stage.update();
 		}
 	}
+
 }
 
 function Record( type, dateTime, record ){

--- a/js/main.js
+++ b/js/main.js
@@ -338,9 +338,11 @@ function GameUI( canvasElem, gameState ){
 
 	this.stage = new createjs.Stage( canvasElem );
 	this.stage.enableMouseOver(25);
-	createjs.Touch.enable(this.stage,false,true);
-	this.stage.preventSelection = false;
+	//createjs.Touch.enable(this.stage);
+	//this.stage.preventSelection = false;
+
 	//https://lucentminds.com/archives/easeljs-touch-mouse-events.html
+	
 	this.activeScreenName = "EndingScreen";
 	this.activeScreenObj = {};
 

--- a/js/main.js
+++ b/js/main.js
@@ -338,8 +338,9 @@ function GameUI( canvasElem, gameState ){
 
 	this.stage = new createjs.Stage( canvasElem );
 	this.stage.enableMouseOver(25);
-	createjs.Touch.enable(this.stage,true,false);
-
+	createjs.Touch.enable(this.stage,false,true);
+	this.stage.preventSelection = false;
+	//https://lucentminds.com/archives/easeljs-touch-mouse-events.html
 	this.activeScreenName = "EndingScreen";
 	this.activeScreenObj = {};
 

--- a/js/main.js
+++ b/js/main.js
@@ -338,10 +338,6 @@ function GameUI( canvasElem, gameState ){
 
 	this.stage = new createjs.Stage( canvasElem );
 	this.stage.enableMouseOver(25);
-	//createjs.Touch.enable(this.stage);
-	//this.stage.preventSelection = false;
-
-	//https://lucentminds.com/archives/easeljs-touch-mouse-events.html
 	
 	this.activeScreenName = "EndingScreen";
 	this.activeScreenObj = {};

--- a/js/stories.js
+++ b/js/stories.js
@@ -5,7 +5,8 @@ var messages = {
 	"NoMoney" : ["Me: I can't afford this!"],
 	"BuyTurkeyFirst" : ["Me: I should buy a turkey first!"],
 	"EmptyOven" : ["Me: I'll start cooking once I get a turkey."],
-	"OpenDoor" :["Me: I should probably try opening the oven door to measure the turkey's temperature."]
+	"OpenDoor" :["Me: I should probably try opening the oven door to measure the turkey's temperature."],
+	"BrokenLight" :["Me: The oven light is broken. I should buy a replacement."]
 }
 
 //Terrible Results
@@ -175,7 +176,7 @@ var story = {
 "Brother: Thanks Grandpa, I'll definitely keep that in mind."],
 
 "Hanging Doorway Ornaments":[
-"Grandma: A real bother these days are the people that decorations in their doorways. They get in your face as you try to walk through.",
+"Grandma: A real bother these days are the people with decorations in their doorways. They get in your face as you try to walk through.",
 "Grandma: And what if there is an Earthquake!",
 "Grandpa: It isn't like we live on a fault line.",
 "Grandma: Just stop hanging your bears in the doorway.",
@@ -475,6 +476,13 @@ var story = {
 "Mom Butter Story":
 ["Mom: My favorite color is butter.",
 "Spouse: That's cool."],
+
+"Secret Debug Story":
+["Spouse: Hey [Player], do you think the universe is just one giant computer simulation?",
+"Spouse: Like, maybe there are secret cheat codes or something.",
+"Spouse: But how would we enter the cheat codes? Wildly flail our arms around in some way?",
+"Spouse: Or maybe we need to eat certain foods on specific days of the week!",
+"Spouse: Hah, that would be funny." ],
 
 "Cat Story":
 ["Cat: Meow Meow Meow Meow Meow",

--- a/js/ui.js
+++ b/js/ui.js
@@ -378,7 +378,7 @@ function OvenUI( stage, gameState ){
 	var OVEN_CLOSED = 0;
 	var OVEN_PEEK = 1;
 	var OVEN_OPEN = 2;
-	var OVEN_TIMER = 0;
+	this.ovenDoorTimer = 0;
 
 	this.ovenDoor = OVEN_CLOSED;
 	var ovenLight = new createjs.Shape();
@@ -519,7 +519,7 @@ function OvenUI( stage, gameState ){
 		if( event.stageY > 300 && that.ovenDoor != OVEN_OPEN){
 			ovenOpen();
 			//Mouse Drag to open fully from peek or closed.
-		}else if (that.ovenDoor == OVEN_PEEK && (Date.now() - OVEN_TIMER <2000)) {
+		} else if (that.ovenDoor == OVEN_PEEK && (Date.now() - that.ovenDoorTimer < 2000)) {
 			//Peek to Open if double clicked within seconds. Meant for Mobile users who cannot drag
 			ovenOpen();
 		}else if( that.ovenDoor == OVEN_CLOSED && that.ovenDoor != OVEN_OPEN ){
@@ -573,7 +573,7 @@ function OvenUI( stage, gameState ){
 
 	function ovenPeek(){
 			that.ovenDoor = OVEN_PEEK;
-			OVEN_TIMER =Date.now();
+			that.ovenDoorTimer = Date.now();
 			gameState.pubsub.publish( "Play", "Oven_Door_Peek_Open" );
 			doorPeekLightOn.alpha = lightPressedImg.alpha;
 			doorPeekLightOff.alpha = !lightPressedImg.alpha;

--- a/js/ui.js
+++ b/js/ui.js
@@ -482,6 +482,10 @@ function OvenUI( stage, gameState ){
 				doorOpen.alpha = 0;
 			}
 		}
+		else
+		{
+			gameState.pubsub.publish("ShowDialog", {seq:"BrokenLight", autoAdvance:true});
+		}
 	}
 
 	this.startTurkeyModel = function(){

--- a/js/ui.js
+++ b/js/ui.js
@@ -434,6 +434,8 @@ function OvenUI( stage, gameState ){
 	var panFront = new createjs.Bitmap( "res/screens/KitchenScreen/PanFront.png" );
 	panFront.alpha = 0;
 
+	var finalButton;
+
 	this.changeTemperature = function( direction ){
 
 		if( gameState.turkeyBought ){
@@ -501,7 +503,7 @@ function OvenUI( stage, gameState ){
  	handleBar.addEventListener( "mouseout", function(){ document.body.style.cursor='default'; } );
  	handleBar.addEventListener( "pressup", handlePress );
 	//handleBar.addEventListener( "click", ovenPeek );
-	
+
     var evalSkin  = {
     	"raw": "The turkey looks no different from when I put it in",
     	"undercooked": "The skin looks pink",
@@ -541,6 +543,7 @@ function OvenUI( stage, gameState ){
 		doorPeekLightOff.alpha = 0;
 		doorOpen.alpha = 0;
 		handleBar.y = 0;
+		finalButton.alpha = 0
 	}
 
 	function ovenOpen() {
@@ -551,6 +554,7 @@ function OvenUI( stage, gameState ){
 		doorOpen.alpha = 1;
 		handleBar.graphics.clear();
 		handleBar.graphics.beginFill("#ffffff").drawRect(5, 450, 400, 60);
+		finalButton.alpha = 0.01;
 
 		if( gameState.turkeyBought ){
 			var state = gameState.ovenModel.getTurkeyState();
@@ -573,6 +577,7 @@ function OvenUI( stage, gameState ){
 			doorClosedLightOff.alpha = 0;
 			doorOpen.alpha = 0;
 			handleBar.y = 48;
+			finalButton.alpha = 0
 
 			if( gameState.turkeyBought ){
 				var state = gameState.ovenModel.getTurkeyState();
@@ -695,14 +700,16 @@ function OvenUI( stage, gameState ){
 
 			//finalize button
 			if( gameState.turkeyBought ){
-				stage.addChild( new Button( stage, gameState, 45, 250, 250, 150, null, null, function(){
+				finalButton = new Button( stage, gameState, 45, 250, 250, 150, null, null, function(){
 					if(!evalSkin[turkeyState["skin"]["cond"][2]]){
 						gameState.pubsub.publish("Death","");
 						return;
 					}
 					gameState.pubsub.publish("Play", "Error");
 					gameState.pubsub.publish("ShowFinalConfirm","");
-				} ) );
+				} ) 
+				finalButton.alpha=0;
+				stage.addChild(finalButton);
 			}
 
 			stage.addChild( doorPeekLightOn);

--- a/js/ui.js
+++ b/js/ui.js
@@ -512,7 +512,6 @@ function OvenUI( stage, gameState ){
     	"burnt": "The turkey looks burnt"
     };
 
-
 	// Look for a drag event
 	function handlePress(event) {
 		if( event.stageY > 300 && that.ovenDoor != OVEN_OPEN){
@@ -542,7 +541,6 @@ function OvenUI( stage, gameState ){
 		doorPeekLightOff.alpha = 0;
 		doorOpen.alpha = 0;
 		handleBar.y = 0;
-		handleBar.alpha = 0.01;
 	}
 
 	function ovenOpen() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -543,7 +543,10 @@ function OvenUI( stage, gameState ){
 		doorPeekLightOff.alpha = 0;
 		doorOpen.alpha = 0;
 		handleBar.y = 0;
-		finalButton.alpha = 0
+
+		if( gameState.turkeyBought ){
+			finalButton.alpha = 0
+		}
 	}
 
 	function ovenOpen() {
@@ -554,9 +557,10 @@ function OvenUI( stage, gameState ){
 		doorOpen.alpha = 1;
 		handleBar.graphics.clear();
 		handleBar.graphics.beginFill("#ffffff").drawRect(5, 450, 400, 60);
-		finalButton.alpha = 0.01;
+
 
 		if( gameState.turkeyBought ){
+			finalButton.alpha = 0.01;
 			var state = gameState.ovenModel.getTurkeyState();
 			if(!evalSkin[turkeyState["skin"]["cond"][2]])
 				gameState.pubsub.publish("Death","");
@@ -577,9 +581,10 @@ function OvenUI( stage, gameState ){
 			doorClosedLightOff.alpha = 0;
 			doorOpen.alpha = 0;
 			handleBar.y = 48;
-			finalButton.alpha = 0
+
 
 			if( gameState.turkeyBought ){
+				finalButton.alpha = 0
 				var state = gameState.ovenModel.getTurkeyState();
 				if(!evalSkin[turkeyState["skin"]["cond"][2]])
 					gameState.pubsub.publish("Death","");

--- a/js/ui.js
+++ b/js/ui.js
@@ -378,6 +378,7 @@ function OvenUI( stage, gameState ){
 	var OVEN_CLOSED = 0;
 	var OVEN_PEEK = 1;
 	var OVEN_OPEN = 2;
+	var OVEN_TIMER = 0;
 
 	this.ovenDoor = OVEN_CLOSED;
 	var ovenLight = new createjs.Shape();
@@ -499,7 +500,8 @@ function OvenUI( stage, gameState ){
  	handleBar.addEventListener( "mouseover", function(){ document.body.style.cursor='pointer'; } );
  	handleBar.addEventListener( "mouseout", function(){ document.body.style.cursor='default'; } );
  	handleBar.addEventListener( "pressup", handlePress );
-
+	//handleBar.addEventListener( "click", ovenPeek );
+	
     var evalSkin  = {
     	"raw": "The turkey looks no different from when I put it in",
     	"undercooked": "The skin looks pink",
@@ -513,49 +515,69 @@ function OvenUI( stage, gameState ){
 
 	// Look for a drag event
 	function handlePress(event) {
-		if( event.stageY > 300 && that.ovenDoor != OVEN_OPEN ){
-			that.ovenDoor = OVEN_OPEN;
-			doorPeekLightOn.alpha = doorClosedLightOn.alpha = 0;
-			doorPeekLightOff.alpha = doorClosedLightOff.alpha = 0;
-			doorOpen.alpha = 1;
-			handleBar.graphics.clear();
-			handleBar.graphics.beginFill("#ffffff").drawRect(5, 450, 400, 60);
-			handleBar.alpha = 0.01;
-
-			if( gameState.turkeyBought ){
-				var state = gameState.ovenModel.getTurkeyState();
-				if(!evalSkin[turkeyState["skin"]["cond"][2]])
-					gameState.pubsub.publish("Death","");
-				gameState.pubsub.publish( "ShowDialog", {seq:"custom", autoAdvance:true, customText:evalSkin[turkeyState["skin"]["cond"][2]] + "." } );
-				gameState.pubsub.publish( "AddRecord", {type:"Open ", text:"The turkey looked " + turkeyState["skin"]["cond"][2]} );
-				gameState.ovenModel.setRawTemp( (gameState.ovenModel.getRawTemp() - 3 ) < 20 ? 20 : gameState.ovenModel.getRawTemp() - 3 );
-				gameState.ovenOpened++;
-			}
-
-			gameState.pubsub.publish( "Play", "Oven_Door_Full_Open" );
-		}else if (that.ovenDoor == OVEN_OPEN ){
-			that.ovenDoor = OVEN_PEEK;
-			gameState.pubsub.publish( "Play", "Oven_Door_Full_Close" );
-			handleBar.graphics.clear();
-		 	handleBar.graphics.beginFill("#ffffff").drawRect(20, 190, 300, 20);
- 			handleBar.alpha = 0.01;
+		if( event.stageY > 300 && that.ovenDoor != OVEN_OPEN){
+			ovenOpen();
+			//Mouse Drag to open fully from peek or closed.
+		}else if (that.ovenDoor == OVEN_PEEK && (Date.now() - OVEN_TIMER <2000)) {
+			//Peek to Open if double clicked within seconds. Meant for Mobile users who cannot drag
+			ovenOpen();
+		}else if( that.ovenDoor == OVEN_CLOSED && that.ovenDoor != OVEN_OPEN ){
 			ovenPeek();
+		}else if (that.ovenDoor == OVEN_OPEN ){
+			ovenClose();
+			gameState.pubsub.publish( "Play", "Oven_Door_Full_Close" );
+		}else if (that.ovenDoor == OVEN_PEEK){
+			ovenClose();
+			gameState.pubsub.publish( "Play", "Oven_Door_Peek_Close" );
 		}
 	}
 
-	handleBar.addEventListener( "click", ovenPeek );
+	function ovenClose() {
+		that.ovenDoor = OVEN_CLOSED;
+		handleBar.graphics.clear();
+		handleBar.graphics.beginFill("#ffffff").drawRect(20, 190, 300, 20);
+		doorClosedLightOn.alpha = lightPressedImg.alpha;
+		doorClosedLightOff.alpha = !lightPressedImg.alpha;
+		doorPeekLightOn.alpha = 0;
+		doorPeekLightOff.alpha = 0;
+		doorOpen.alpha = 0;
+		handleBar.y = 0;
+		handleBar.alpha = 0.01;
+	}
+
+	function ovenOpen() {
+		that.ovenDoor = OVEN_OPEN;
+		doorPeekLightOn.alpha = doorClosedLightOn.alpha = 0;
+		doorPeekLightOff.alpha = doorClosedLightOff.alpha = 0;
+		doorOpen.alpha = 1;
+		handleBar.graphics.clear();
+		handleBar.graphics.beginFill("#ffffff").drawRect(5, 450, 400, 60);
+		handleBar.alpha = 0.01;
+
+		if( gameState.turkeyBought ){
+			var state = gameState.ovenModel.getTurkeyState();
+			if(!evalSkin[turkeyState["skin"]["cond"][2]])
+				gameState.pubsub.publish("Death","");
+			gameState.pubsub.publish( "ShowDialog", {seq:"custom", autoAdvance:true, customText:evalSkin[turkeyState["skin"]["cond"][2]] + "." } );
+			gameState.pubsub.publish( "AddRecord", {type:"Open ", text:"The turkey looked " + turkeyState["skin"]["cond"][2]} );
+			gameState.ovenModel.setRawTemp( (gameState.ovenModel.getRawTemp() - 3 ) < 20 ? 20 : gameState.ovenModel.getRawTemp() - 3 );
+			gameState.ovenOpened++;
+		}
+
+		gameState.pubsub.publish( "Play", "Oven_Door_Full_Open" );
+		}
 
 	function ovenPeek(){
-		if( that.ovenDoor == OVEN_CLOSED && that.ovenDoor != OVEN_OPEN ){
+			that.ovenDoor = OVEN_PEEK;
+			OVEN_TIMER =Date.now();
 			gameState.pubsub.publish( "Play", "Oven_Door_Peek_Open" );
 			doorPeekLightOn.alpha = lightPressedImg.alpha;
 			doorPeekLightOff.alpha = !lightPressedImg.alpha;
 			doorClosedLightOn.alpha = 0;
 			doorClosedLightOff.alpha = 0;
 			doorOpen.alpha = 0;
-			that.ovenDoor = OVEN_PEEK;
-
 			handleBar.y = 48;
+
 			if( gameState.turkeyBought ){
 				var state = gameState.ovenModel.getTurkeyState();
 				if(!evalSkin[turkeyState["skin"]["cond"][2]])
@@ -563,19 +585,8 @@ function OvenUI( stage, gameState ){
 				gameState.pubsub.publish( "ShowDialog", {seq:"custom", autoAdvance:true, customText:evalSkin[turkeyState["skin"]["cond"][2]] } );
 				gameState.pubsub.publish( "AddRecord", {type:"Peek ", text:"The turkey looked " +turkeyState["skin"]["cond"][2]} );
 			}
-		}
-		else if (that.ovenDoor == OVEN_PEEK){
-			doorClosedLightOn.alpha = lightPressedImg.alpha;
-			doorClosedLightOff.alpha = !lightPressedImg.alpha;
-			doorPeekLightOn.alpha = 0;
-			doorPeekLightOff.alpha = 0;
-			that.ovenDoor = OVEN_CLOSED;
-			gameState.pubsub.publish( "Play", "Oven_Door_Peek_Close" );
-			doorOpen.alpha = 0;
-			handleBar.y = 0;
-		}
 	}
-
+	
 	// Show core temperature
 	this.showTempDialog = function(){
 		if( that.ovenDoor != OVEN_OPEN ){

--- a/js/ui.js
+++ b/js/ui.js
@@ -545,12 +545,12 @@ function OvenUI( stage, gameState ){
 
 	function ovenOpen() {
 		that.ovenDoor = OVEN_OPEN;
+		gameState.pubsub.publish( "Play", "Oven_Door_Full_Open" );
 		doorPeekLightOn.alpha = doorClosedLightOn.alpha = 0;
 		doorPeekLightOff.alpha = doorClosedLightOff.alpha = 0;
 		doorOpen.alpha = 1;
 		handleBar.graphics.clear();
 		handleBar.graphics.beginFill("#ffffff").drawRect(5, 450, 400, 60);
-		handleBar.alpha = 0.01;
 
 		if( gameState.turkeyBought ){
 			var state = gameState.ovenModel.getTurkeyState();
@@ -561,9 +561,7 @@ function OvenUI( stage, gameState ){
 			gameState.ovenModel.setRawTemp( (gameState.ovenModel.getRawTemp() - 3 ) < 20 ? 20 : gameState.ovenModel.getRawTemp() - 3 );
 			gameState.ovenOpened++;
 		}
-
-		gameState.pubsub.publish( "Play", "Oven_Door_Full_Open" );
-		}
+	}
 
 	function ovenPeek(){
 			that.ovenDoor = OVEN_PEEK;


### PR DESCRIPTION
1) Added ability to open oven door fully by tapping/clicking twice within 2 seconds. Workaround for #17 
2) Updated to CreateJS version 1.0.  This fixes sound looping on Firefox. 
3) CreateJS version 1.0 broke the sort order for the button to remove the turkey from the oven. Added new alpha for this button to prevent pressing button until oven is open.
4) Added new dialogue for when the oven light switch is pressed, but the light bulb was not purchased. Enhancement #10 

Please test and review. Thank You!

EDIT by @fernjager: Added the `Fixes` keywords linking to the relevant GH issues so that they'll be automatically closed once this PR is merged 👍 

Fixes #17 
Fixes #10 
